### PR TITLE
vitaldr: add library name when the imported symbol is unknown

### DIFF
--- a/src/vita/psp2_loader.cpp
+++ b/src/vita/psp2_loader.cpp
@@ -622,12 +622,18 @@ void psp2_loader::loadExports(uint32 entTop, uint32 entEnd) {
           auto nid = get_long(nidoffset);
           auto add = get_long(addoffset);
 
+          if (add & 1)
+            add -= 1;
+
           auto resolvedNid = getNameFromDatabase(nid);
           if (resolvedNid) {
             set_cmt(nidoffset, resolvedNid, false);
-            if (add & 1)
-              add -= 1;
             do_name_anyway(add, resolvedNid);
+          } else {
+            msg("unknown export %08X\n", nid);
+            qstring qfuncname;
+            qfuncname.sprnt("export_%08X", nid);
+            do_name_anyway(add, qfuncname.c_str());
           }
 
           if (i < nfunc)


### PR DESCRIPTION
Instead of having `sub_81086530` for unknown imports, this now gives `ScePafToplevel_seg000_81086530`